### PR TITLE
mdio: align buffer

### DIFF
--- a/src/mdio/mdio.c
+++ b/src/mdio/mdio.c
@@ -184,7 +184,7 @@ err_invalid:
 	return EINVAL;
 }
 
-static char buf[0x1000];
+static char buf[0x1000] __attribute__ ((aligned (NLMSG_ALIGNTO)));
 static const size_t len = 0x1000;
 static uint16_t mdio_family;
 


### PR DESCRIPTION
During cross-compilation and testing this tool for OpenWrt inclusion
(see https://github.com/openwrt/packages/pull/16112), I found that
the tool immediately segfaults after start.

Further investigations showed that on at least arm926ej-s based boards,
the buf variable should be aligned - without alignment the members in
the structure do not have desired values.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>