### PR TITLE
Run autogen.sh in non GIT environment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell Scripts always with LF EOL
+#
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,0 @@
-# Shell Scripts always with LF EOL
-#
-*.sh text eol=lf

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,39 @@
 #!/bin/sh
 
+# Required Packages
+REQPKG="autoconf automake pkg-config libmnl-dev"
+
+
+# check for all dependencies
+pkg2install=""
+for actPkg in ${REQPKG}; do
+    if [ -z "$(dpkg -s ${actPkg} | grep -o "install ok installed")" ]; then
+        pkg2install="${pkg2install} ${actPkg}"
+    fi
+done
+pkg2install=${pkg2install##*( )}    # remove leading blanks
+if [ ! -z ${pkg2install} ]; then
+    echo "Required Packages missing, try:"
+    echo "  sudo apt-get update && apt-get install ${pkg2install} -y"
+    #exit 1;
+fi
+
+
+# create if not exist
+if [ ! -d "./m4" ]; then
+   mkdir -p ./m4
+fi
+
+
+# No git repo, make static version in 'configure.ac'
+#  https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/Initializing-configure.html
+if [ ! -d ".git" ]; then
+   # make backup
+   cp ./configure.ac ./configure.bak
+   # replace 'm4_esyscmd_s(git describe --always --dirty --tags)' with 'Unknown'
+   sed -i 's/m4_esyscmd_s(git describe --always --dirty --tags)/Unknown/g' ./configure.ac
+fi
+
+
+# build make scripts
 autoreconf -W portability -vifm


### PR DESCRIPTION
If I run ./autogen.sh after direct download from Github I encouter follwoing messages:
```bash
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force --warnings=portability -I m4
aclocal: warning: couldn't open directory 'm4': No such file or directory
sh: 1: git: not found
configure.ac:5: error: AC_INIT should be called with package and version arguments
/usr/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
configure.ac:5: the top level
autom4te: /usr/bin/m4 failed with exit status: 1
aclocal: error: /usr/bin/autom4te failed with exit status: 1
autoreconf: aclocal failed with exit status: 1
```
This script allows the compile in such a case. Following features are implemented:
* If non GIT environment is detected bypass call in configure.ac to git
* Create missing directory 'm4'
* Check for dependencies to install
