### PR TITLE
shell script always with LF EOL encoding checked-out

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell Scripts always with LF EOL
+#
+*.sh text eol=lf


### PR DESCRIPTION
In case of Windows GIT checkout is the shell script with CR messed up. As described in https://github.com/wkz/mdio-tools/pull/6 done with own commit.
