### PR TITLE
mdio: bench: make time_t prints portable

### DIFF
--- a/src/mdio/mdio.c
+++ b/src/mdio/mdio.c
@@ -552,13 +552,13 @@ int mdio_common_bench_cb(uint32_t *data, int len, int err, void *_start)
 		printf("Performed 1000 reads in ");
 
 	if (end.tv_sec)
-		printf("%ld.%2.2lds\n", end.tv_sec, end.tv_nsec / 10000000);
+		printf("%"PRId64".%2.2"PRId64"s\n", (int64_t)end.tv_sec, (int64_t)end.tv_nsec / 10000000);
 	else if (end.tv_nsec > 1000000)
-		printf("%ldms\n", end.tv_nsec / 1000000);
+		printf("%"PRId64"ms\n", (int64_t)end.tv_nsec / 1000000);
 	else if (end.tv_nsec > 1000)
-		printf("%ldus\n", end.tv_nsec / 1000);
+		printf("%"PRId64"us\n", (int64_t)end.tv_nsec / 1000);
 	else
-		printf("%ldns\n", end.tv_nsec);
+		printf("%"PRId64"ns\n", (int64_t)end.tv_nsec);
 
 	return err;
 }


### PR DESCRIPTION
Using %ld to print time_t will work fine on 64 bit platforms, however
now musl libc defines time_t to be 64 even on 32bit platforms.

This will make the compilation fail with:
```
mdio.c: In function 'mdio_common_bench_cb':
mdio.c:555:27: error: format '%ld' expects argument of type 'long int', but argument 2 has type 'time_t' {aka 'long long int'} [-Werror=format=]
  555 |                 printf("%ld.%2.2lds\n", end.tv_sec, end.tv_nsec / 10000000);
      |                         ~~^             ~~~~~~~~~~
      |                           |                |
      |                           long int         time_t {aka long long int}
      |                         %lld

```
So, replace the %ld in prints with the PRId64 from inttypes.h and cast
tv_sec and tv_nsec to int64_t.

This makes it compile and work on 32 bit ARMv7 fine.

Signed-off-by: Robert Marko <robert.marko@sartura.hr>