### PR TITLE
Add support for c45 devices

### DIFF
--- a/include/linux/bitfield.h
+++ b/include/linux/bitfield.h
@@ -1,0 +1,145 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (C) 2014 Felix Fietkau <nbd@nbd.name>
+ * Copyright (C) 2004 - 2009 Ivo van Doorn <IvDoorn@gmail.com>
+ */
+
+#ifndef _LINUX_BITFIELD_H
+#define _LINUX_BITFIELD_H
+
+#include <asm/byteorder.h>
+
+/*
+ * Bitfield access macros
+ *
+ * FIELD_{GET,PREP} macros take as first parameter shifted mask
+ * from which they extract the base mask and shift amount.
+ * Mask must be a compilation time constant.
+ *
+ * Example:
+ *
+ *  #include <linux/bitfield.h>
+ *  #include <linux/bits.h>
+ *
+ *  #define REG_FIELD_A  GENMASK(6, 0)
+ *  #define REG_FIELD_B  BIT(7)
+ *  #define REG_FIELD_C  GENMASK(15, 8)
+ *  #define REG_FIELD_D  GENMASK(31, 16)
+ *
+ * Get:
+ *  a = FIELD_GET(REG_FIELD_A, reg);
+ *  b = FIELD_GET(REG_FIELD_B, reg);
+ *
+ * Set:
+ *  reg = FIELD_PREP(REG_FIELD_A, 1) |
+ *	  FIELD_PREP(REG_FIELD_B, 0) |
+ *	  FIELD_PREP(REG_FIELD_C, c) |
+ *	  FIELD_PREP(REG_FIELD_D, 0x40);
+ *
+ * Modify:
+ *  reg &= ~REG_FIELD_C;
+ *  reg |= FIELD_PREP(REG_FIELD_C, c);
+ */
+
+#define __bf_shf(x) (__builtin_ffsll(x) - 1)
+
+#define __BF_FIELD_CHECK(_mask, _reg, _val, _pfx)
+
+/**
+ * FIELD_MAX() - produce the maximum value representable by a field
+ * @_mask: shifted mask defining the field's length and position
+ *
+ * FIELD_MAX() returns the maximum value that can be held in the field
+ * specified by @_mask.
+ */
+#define FIELD_MAX(_mask)						\
+	({								\
+		__BF_FIELD_CHECK(_mask, 0ULL, 0ULL, "FIELD_MAX: ");	\
+		(typeof(_mask))((_mask) >> __bf_shf(_mask));		\
+	})
+
+/**
+ * FIELD_FIT() - check if value fits in the field
+ * @_mask: shifted mask defining the field's length and position
+ * @_val:  value to test against the field
+ *
+ * Return: true if @_val can fit inside @_mask, false if @_val is too big.
+ */
+#define FIELD_FIT(_mask, _val)						\
+	({								\
+		__BF_FIELD_CHECK(_mask, 0ULL, 0ULL, "FIELD_FIT: ");	\
+		!((((typeof(_mask))_val) << __bf_shf(_mask)) & ~(_mask)); \
+	})
+
+/**
+ * FIELD_PREP() - prepare a bitfield element
+ * @_mask: shifted mask defining the field's length and position
+ * @_val:  value to put in the field
+ *
+ * FIELD_PREP() masks and shifts up the value.  The result should
+ * be combined with other fields of the bitfield using logical OR.
+ */
+#define FIELD_PREP(_mask, _val)						\
+	({								\
+		__BF_FIELD_CHECK(_mask, 0ULL, _val, "FIELD_PREP: ");	\
+		((typeof(_mask))(_val) << __bf_shf(_mask)) & (_mask);	\
+	})
+
+/**
+ * FIELD_GET() - extract a bitfield element
+ * @_mask: shifted mask defining the field's length and position
+ * @_reg:  value of entire bitfield
+ *
+ * FIELD_GET() extracts the field specified by @_mask from the
+ * bitfield passed in as @_reg by masking and shifting it down.
+ */
+#define FIELD_GET(_mask, _reg)						\
+	({								\
+		__BF_FIELD_CHECK(_mask, _reg, 0U, "FIELD_GET: ");	\
+		(typeof(_mask))(((_reg) & (_mask)) >> __bf_shf(_mask));	\
+	})
+
+extern void __field_overflow(void);
+extern void __bad_mask(void);
+static __always_inline uint64_t field_multiplier(uint64_t field)
+{
+	if ((field | (field - 1)) & ((field | (field - 1)) + 1))
+		__bad_mask();
+	return field & -field;
+}
+static __always_inline uint64_t field_mask(uint64_t field)
+{
+	return field / field_multiplier(field);
+}
+#define field_max(field)	((typeof(field))field_mask(field))
+#define ____MAKE_OP(type,base,to,from)					\
+static __always_inline type type##_encode_bits(base v, base field)	\
+{									\
+	if (__builtin_constant_p(v) && (v & ~field_mask(field)))	\
+		__field_overflow();					\
+	return to((v & field_mask(field)) * field_multiplier(field));	\
+}									\
+static __always_inline type type##_replace_bits(type old,	\
+					base val, base field)		\
+{									\
+	return (old & ~to(field)) | type##_encode_bits(val, field);	\
+}									\
+static __always_inline void type##p_replace_bits(type *p,		\
+					base val, base field)		\
+{									\
+	*p = (*p & ~to(field)) | type##_encode_bits(val, field);	\
+}									\
+static __always_inline base type##_get_bits(type v, base field)	\
+{									\
+	return (from(v) & field)/field_multiplier(field);		\
+}
+#define __MAKE_OP(size)							\
+	____MAKE_OP(uint##size##_t,uint##size##_t,,)
+__MAKE_OP(8)
+__MAKE_OP(16)
+__MAKE_OP(32)
+__MAKE_OP(64)
+#undef __MAKE_OP
+#undef ____MAKE_OP
+
+#endif

--- a/src/mdio/mdio.h
+++ b/src/mdio/mdio.h
@@ -73,6 +73,13 @@ void print_mmd_devid(uint16_t id_hi, uint16_t id_lo);
 void print_mmd_pkgid(uint16_t id_hi, uint16_t id_lo);
 void print_mmd_devs (uint16_t devs_hi, uint16_t devs_lo);
 
+struct mmd_print_device {
+	void (*print_ctrl1)(uint16_t val);
+	void (*print_stat1)(uint16_t val);
+	void (*print_speed)(uint16_t val);
+	void (*print_extra)(uint32_t *data);
+};
+
 int mdio_parse_bus(const char *str, char **bus);
 int mdio_parse_dev(const char *str, uint16_t *dev, bool allow_c45);
 int mdio_parse_reg(const char *str, uint16_t *reg, bool is_c45);

--- a/src/mdio/mdio.h
+++ b/src/mdio/mdio.h
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include <linux/mdio-netlink.h>
 
+#define BIT(_n) (1 << (_n))
+
 #define ARRAY_SIZE(_a) (sizeof(_a) / sizeof((_a)[0]))
 #define container_of(ptr, type, member) ({	\
 	const typeof( ((type *)0)->member )	\

--- a/src/mdio/mdio.h
+++ b/src/mdio/mdio.h
@@ -81,6 +81,7 @@ struct mmd_print_device {
 };
 
 extern const struct mmd_print_device pma_print_device;
+extern const struct mmd_print_device pcs_print_device;
 
 int mdio_parse_bus(const char *str, char **bus);
 int mdio_parse_dev(const char *str, uint16_t *dev, bool allow_c45);

--- a/src/mdio/mdio.h
+++ b/src/mdio/mdio.h
@@ -82,6 +82,7 @@ struct mmd_print_device {
 
 extern const struct mmd_print_device pma_print_device;
 extern const struct mmd_print_device pcs_print_device;
+extern const struct mmd_print_device an_print_device;
 
 int mdio_parse_bus(const char *str, char **bus);
 int mdio_parse_dev(const char *str, uint16_t *dev, bool allow_c45);

--- a/src/mdio/mdio.h
+++ b/src/mdio/mdio.h
@@ -80,6 +80,8 @@ struct mmd_print_device {
 	void (*print_extra)(uint32_t *data);
 };
 
+extern const struct mmd_print_device pma_print_device;
+
 int mdio_parse_bus(const char *str, char **bus);
 int mdio_parse_dev(const char *str, uint16_t *dev, bool allow_c45);
 int mdio_parse_reg(const char *str, uint16_t *reg, bool is_c45);

--- a/src/mdio/mdio.h
+++ b/src/mdio/mdio.h
@@ -64,9 +64,10 @@ extern struct cmd __stop_cmds;
 int mdio_raw_read_cb (uint32_t *data, int len, int err, void *_null);
 int mdio_raw_write_cb(uint32_t *data, int len, int err, void *_null);
 
-void print_phy_bmcr(uint16_t val);
-void print_phy_bmsr(uint16_t val);
-void print_phy_id  (uint16_t id_hi, uint16_t id_lo);
+void print_phy_bmcr   (uint16_t val);
+void print_phy_bmsr   (uint16_t val);
+void print_phy_id     (uint16_t id_hi, uint16_t id_lo);
+void print_phy_estatus(uint16_t val);
 
 int mdio_parse_bus(const char *str, char **bus);
 int mdio_parse_dev(const char *str, uint16_t *dev, bool allow_c45);

--- a/src/mdio/mdio.h
+++ b/src/mdio/mdio.h
@@ -69,6 +69,10 @@ void print_phy_bmsr   (uint16_t val);
 void print_phy_id     (uint16_t id_hi, uint16_t id_lo);
 void print_phy_estatus(uint16_t val);
 
+void print_mmd_devid(uint16_t id_hi, uint16_t id_lo);
+void print_mmd_pkgid(uint16_t id_hi, uint16_t id_lo);
+void print_mmd_devs (uint16_t devs_hi, uint16_t devs_lo);
+
 int mdio_parse_bus(const char *str, char **bus);
 int mdio_parse_dev(const char *str, uint16_t *dev, bool allow_c45);
 int mdio_parse_reg(const char *str, uint16_t *reg, bool is_c45);

--- a/src/mdio/mvls.c
+++ b/src/mdio/mvls.c
@@ -7,8 +7,6 @@
 
 #include "mdio.h"
 
-#define BIT(_n) (1 << (_n))
-
 #define MVLS_CMD  0
 #define MVLS_CMD_BUSY BIT(15)
 #define MVLS_CMD_C22  BIT(12)

--- a/src/mdio/phy.c
+++ b/src/mdio/phy.c
@@ -172,6 +172,9 @@ int mmd_exec_status(struct phy_device *pdev, int argc, char **argv)
 	int err;
 
 	switch (FIELD_GET(MDIO_PHY_ID_DEVAD, pdev->id)) {
+	case MDIO_MMD_PMAPMD:
+		dev = &pma_print_device;
+		break;
 	default:
 		dev = &null_print_device;
 		break;

--- a/src/mdio/phy.c
+++ b/src/mdio/phy.c
@@ -34,7 +34,7 @@ static const struct mdio_driver phy_driver = {
 
 int phy_status_cb(uint32_t *data, int len, int err, void *_null)
 {
-	if (len != 4)
+	if (len != 5)
 		return 1;
 
 	if (data[2] == 0xffff && data[3] == 0xffff) {
@@ -47,6 +47,10 @@ int phy_status_cb(uint32_t *data, int len, int err, void *_null)
 	print_phy_bmsr(data[1]);
 	putchar('\n');
 	print_phy_id(data[2], data[3]);
+	if (data[1] & BMSR_ESTATEN) {
+		putchar('\n');
+		print_phy_estatus(data[4]);
+	}
 
 	return err;
 }
@@ -61,6 +65,8 @@ int phy_exec_status(struct phy_device *pdev, int argc, char **argv)
 		INSN(READ,  IMM(pdev->id), IMM(2),  REG(0)),
 		INSN(EMIT,  REG(0),   0,         0),
 		INSN(READ,  IMM(pdev->id), IMM(3),  REG(0)),
+		INSN(EMIT,  REG(0),   0,         0),
+		INSN(READ,  IMM(pdev->id), IMM(15),  REG(0)),
 		INSN(EMIT,  REG(0),   0,         0),
 	};
 	struct mdio_prog prog = MDIO_PROG_FIXED(insns);

--- a/src/mdio/phy.c
+++ b/src/mdio/phy.c
@@ -175,6 +175,9 @@ int mmd_exec_status(struct phy_device *pdev, int argc, char **argv)
 	case MDIO_MMD_PMAPMD:
 		dev = &pma_print_device;
 		break;
+	case MDIO_MMD_PCS:
+		dev = &pcs_print_device;
+		break;
 	default:
 		dev = &null_print_device;
 		break;

--- a/src/mdio/phy.c
+++ b/src/mdio/phy.c
@@ -178,6 +178,9 @@ int mmd_exec_status(struct phy_device *pdev, int argc, char **argv)
 	case MDIO_MMD_PCS:
 		dev = &pcs_print_device;
 		break;
+	case MDIO_MMD_AN:
+		dev = &an_print_device;
+		break;
 	default:
 		dev = &null_print_device;
 		break;

--- a/src/mdio/print_phy.c
+++ b/src/mdio/print_phy.c
@@ -113,3 +113,21 @@ void print_phy_id(uint16_t id_hi, uint16_t id_lo)
 
 	printf("ID(0x02/0x03): %#.8x\n", id);
 }
+
+void print_phy_estatus(uint16_t val)
+{
+	printf("ESTATUS(0x0F): %#.4x\n", val);
+
+	fputs("  capabilities: ", stdout);
+	print_bool("1000-x-f", val & ESTATUS_1000_XFULL);
+	putchar(' ');
+
+	print_bool("1000-x-h", val & ESTATUS_1000_XHALF);
+	putchar(' ');
+
+	print_bool("1000-t-f", val & ESTATUS_1000_TFULL);
+	putchar(' ');
+
+	print_bool("1000-t-h", val & ESTATUS_1000_THALF);
+	putchar('\n');
+}

--- a/src/mdio/print_phy.c
+++ b/src/mdio/print_phy.c
@@ -19,15 +19,37 @@ void print_bool(const char *name, int on)
 		fputs("\e[0m", stdout);
 }
 
+static const char *get_speed(uint16_t val)
+{
+	switch (val & MDIO_CTRL1_SPEEDSELEXT) {
+	case MDIO_PMA_CTRL1_SPEED1000:
+		return "1000";
+	case MDIO_PMA_CTRL1_SPEED100:
+		return "100";
+	case 0:
+		return "10";
+	}
+
+	switch (val & MDIO_CTRL1_SPEEDSEL) {
+	case (MDIO_CTRL1_SPEEDSELEXT | 0x0c):
+		return "100g";
+	case (MDIO_CTRL1_SPEEDSELEXT | 0x08):
+		return "40g";
+	case MDIO_CTRL1_SPEED10G:
+		return "10g";
+	case MDIO_CTRL1_SPEED10P2B:
+		return "10-ts/2-tl";
+	case MDIO_CTRL1_SPEED2_5G:
+		return "2.5g";
+	case MDIO_CTRL1_SPEED5G:
+		return "5g";
+	default:
+		return "unknown";
+	}
+}
+
 void print_phy_bmcr(uint16_t val)
 {
-	int speed = 10;
-
-	if (val & BMCR_SPEED100)
-		speed = 100;
-	if (val & BMCR_SPEED1000)
-		speed = 1000;
-
 	printf("BMCR(0x00): %#.4x\n", val);
 
 	fputs("  flags: ", stdout);
@@ -53,7 +75,7 @@ void print_phy_bmcr(uint16_t val)
 	print_bool("collision-test", val & BMCR_CTST);
 	putchar('\n');
 
-	printf("  speed: %d-%s\n", speed,
+	printf("  speed: %s-%s\n", get_speed(val),
 	       (val & BMCR_FULLDPLX) ? "full" : "half");
 }
 

--- a/src/mdio/print_phy.c
+++ b/src/mdio/print_phy.c
@@ -153,3 +153,71 @@ void print_phy_estatus(uint16_t val)
 	print_bool("1000-t-h", val & ESTATUS_1000_THALF);
 	putchar('\n');
 }
+
+void print_mmd_devid(uint16_t id_hi, uint16_t id_lo)
+{
+	uint32_t id = (id_hi << 16) | id_lo;
+
+	printf("DEVID(0x02/0x03): %#.8x\n", id);
+}
+
+void print_mmd_pkgid(uint16_t id_hi, uint16_t id_lo)
+{
+	uint32_t id = (id_hi << 16) | id_lo;
+
+	printf("PKGID(0x0E/0x0F): %#.8x\n", id);
+}
+
+void print_mmd_devs(uint16_t devs_hi, uint16_t devs_lo)
+{
+	uint32_t devs = devs_hi << 16 | devs_lo;
+
+	printf("DEVS(0x06/0x05): %#.8x\n", devs);
+
+	fputs("  devices: ", stdout);
+	print_bool("vendor2", devs & MDIO_DEVS_VEND2);
+	putchar(' ');
+
+	print_bool("vendor1", devs & MDIO_DEVS_VEND1);
+	putchar(' ');
+
+	print_bool("c22-ext", devs & MDIO_DEVS_C22EXT);
+	putchar(' ');
+
+	print_bool("pma4", devs & MDIO_DEVS_PRESENT(11));
+	putchar(' ');
+
+	print_bool("pma3", devs & MDIO_DEVS_PRESENT(10));
+	putchar(' ');
+
+	print_bool("pma2", devs & MDIO_DEVS_PRESENT(9));
+	putchar(' ');
+
+	print_bool("pma1", devs & MDIO_DEVS_PRESENT(8));
+	fputs("\n"
+	      "           ", stdout);
+
+	print_bool("aneg", devs & MDIO_DEVS_AN);
+	putchar(' ');
+
+	print_bool("tc", devs & MDIO_DEVS_TC);
+	putchar(' ');
+
+	print_bool("dte-xs", devs & MDIO_DEVS_DTEXS);
+	putchar(' ');
+
+	print_bool("phy-xs", devs & MDIO_DEVS_PHYXS);
+	putchar(' ');
+
+	print_bool("pcs", devs & MDIO_DEVS_PCS);
+	putchar(' ');
+
+	print_bool("wis", devs & MDIO_DEVS_WIS);
+	putchar(' ');
+
+	print_bool("pma/pmd", devs & MDIO_DEVS_PMAPMD);
+	putchar(' ');
+
+	print_bool("c22", devs & MDIO_DEVS_C22PRESENT);
+	putchar('\n');
+}

--- a/src/mdio/print_phy.c
+++ b/src/mdio/print_phy.c
@@ -62,19 +62,19 @@ void print_phy_bmsr(uint16_t val)
 	printf("BMSR(0x01): %#.4x\n", val);
 
 	fputs("  capabilities: ", stdout);
-	print_bool("100-b4", val & BMSR_100BASE4);
+	print_bool("100-t4", val & BMSR_100BASE4);
 	putchar(' ');
 
-	print_bool("100-f", val & BMSR_100FULL);
+	print_bool("100-tx-f", val & BMSR_100FULL);
 	putchar(' ');
 
-	print_bool("100-h", val & BMSR_100HALF);
+	print_bool("100-tx-h", val & BMSR_100HALF);
 	putchar(' ');
 
-	print_bool("10-f", val & BMSR_10FULL);
+	print_bool("10-t-f", val & BMSR_10FULL);
 	putchar(' ');
 
-	print_bool("10-h", val & BMSR_10HALF);
+	print_bool("10-t-h", val & BMSR_10HALF);
 	putchar(' ');
 
 	print_bool("100-t2-f", val & BMSR_100FULL2);

--- a/src/mdio/print_phy.c
+++ b/src/mdio/print_phy.c
@@ -471,3 +471,141 @@ const struct mmd_print_device pma_print_device = {
 	.print_speed = print_pma_speed,
 	.print_extra = print_pma_extra,
 };
+
+static void print_pcs_ctrl1(uint16_t val)
+{
+	printf("CTRL1(0x00): %#.4x\n", val);
+
+	fputs("  flags: ", stdout);
+	print_bool("reset", val & MDIO_CTRL1_RESET);
+	putchar(' ');
+
+	print_bool("loopback", val & MDIO_PCS_CTRL1_LOOPBACK);
+	putchar(' ');
+
+	print_bool("low-power", val & MDIO_CTRL1_LPOWER);
+	putchar(' ');
+
+	print_bool("lpi-clock-stop", val & MDIO_PCS_CTRL1_CLKSTOP_EN);
+	putchar(' ');
+
+	putchar('\n');
+
+	printf("  speed: %s\n", get_speed(val));
+}
+
+static void print_pcs_stat1(uint16_t val)
+{
+	printf("STAT1(0x01): %#.4x\n", val);
+
+	fputs("  capabilities: ", stdout);
+	print_bool("lpi-clock-stop", val & BIT(6));
+	putchar(' ');
+
+	print_bool("low-power", val & MDIO_STAT1_LPOWERABLE);
+	putchar('\n');
+
+	fputs("  flags:        ", stdout);
+	print_bool("rx-lpi-recv", val & BIT(11));
+	putchar(' ');
+
+	print_bool("tx-lpi-recv", val & BIT(10));
+	putchar(' ');
+
+	print_bool("rx-lpi-ind", val & BIT(9));
+	putchar(' ');
+
+	print_bool("tx-lpi-ind", val & BIT(8));
+	putchar(' ');
+
+	print_bool("fault", val & MDIO_STAT1_FAULT);
+	putchar(' ');
+
+	print_bool("link", val & MDIO_STAT1_LSTATUS);
+	putchar('\n');
+}
+
+static void print_pcs_speed(uint16_t val)
+{
+	printf("SPEED(0x04): %#.4x\n", val);
+
+	fputs("  capabilities: ", stdout);
+	print_bool("100g", val & BIT(3));
+	putchar(' ');
+
+	print_bool("40g", val & BIT(2));
+	putchar(' ');
+
+	print_bool("10-ts/2-tl", val & MDIO_PCS_SPEED_10P2B);
+	putchar(' ');
+
+	print_bool("10g", val & MDIO_SPEED_10G);
+	putchar('\n');
+}
+
+static const char *get_pcs_type(uint16_t val)
+{
+	switch (FIELD_GET(MDIO_PCS_CTRL2_TYPE, val)) {
+	case 0x0005:
+		return "100g-r";
+	case 0x0004:
+		return "40g-r";
+	case MDIO_PCS_CTRL2_10GBT:
+		return "10g-t";
+	case MDIO_PCS_CTRL2_10GBW:
+		return "10g-w";
+	case MDIO_PCS_CTRL2_10GBX:
+		return "10g-x";
+	case MDIO_PCS_CTRL2_10GBR:
+		return "10g-r";
+	default:
+		return "unknown";
+	}
+}
+
+static void print_pcs_ctrl2(uint16_t val)
+{
+	printf("CTRL2(0x07): %#.4x\n", val);
+
+	printf("  type: %s\n", get_pcs_type(val));
+}
+
+static void print_pcs_stat2(uint16_t val)
+{
+	printf("STAT2(0x08): %#.4x\n", val);
+
+	fputs("  capabilities: ", stdout);
+	print_bool("100g-r", val & BIT(5));
+	putchar(' ');
+
+	print_bool("40g-r", val & BIT(4));
+	putchar(' ');
+
+	print_bool("10g-t", val & BIT(3));
+	putchar(' ');
+
+	print_bool("10g-w", val & MDIO_PCS_STAT2_10GBW);
+	putchar(' ');
+
+	print_bool("10g-x", val & MDIO_PCS_STAT2_10GBX);
+	putchar(' ');
+
+	print_bool("10g-r", val & MDIO_PCS_STAT2_10GBR);
+	putchar('\n');
+
+	print_mmd_stat2_flags(val);
+}
+
+static void print_pcs_extra(uint32_t *data)
+{
+	print_pcs_ctrl2(data[7]);
+	putchar('\n');
+	print_pcs_stat2(data[8]);
+}
+
+const struct mmd_print_device pcs_print_device = {
+	.print_ctrl1 = print_pcs_ctrl1,
+	.print_stat1 = print_pcs_stat1,
+	.print_speed = print_pcs_speed,
+	.print_extra = print_pcs_extra,
+};

--- a/src/mdio/print_phy.c
+++ b/src/mdio/print_phy.c
@@ -609,3 +609,58 @@ const struct mmd_print_device pcs_print_device = {
 	.print_speed = print_pcs_speed,
 	.print_extra = print_pcs_extra,
 };
+
+static void print_an_ctrl1(uint16_t val)
+{
+	printf("CTRL1(0x00): %#.4x\n", val);
+
+	fputs("  flags: ", stdout);
+	print_bool("reset", val & MDIO_CTRL1_RESET);
+	putchar(' ');
+
+	print_bool("ext-page", val & MDIO_AN_CTRL1_XNP);
+	putchar(' ');
+
+	print_bool("aneg-enable", val & MDIO_AN_CTRL1_ENABLE);
+	putchar(' ');
+
+	print_bool("aneg-restart", val & MDIO_AN_CTRL1_RESTART);
+	putchar('\n');
+}
+
+static void print_an_stat1(uint16_t val)
+{
+	printf("STAT1(0x01): %#.4x\n", val);
+
+	fputs("  capabilities: ", stdout);
+	print_bool("aneg-capable", val & MDIO_AN_STAT1_ABLE);
+	putchar(' ');
+
+	print_bool("partner-capable", val & MDIO_AN_STAT1_LPABLE);
+	putchar('\n');
+
+	fputs("  flags:        ", stdout);
+	print_bool("ext-page", val & MDIO_AN_STAT1_XNP);
+	putchar(' ');
+
+	print_bool("parallel-fault", val & MDIO_STAT1_FAULT);
+	putchar(' ');
+
+	print_bool("page", val & MDIO_AN_STAT1_PAGE);
+	putchar(' ');
+
+	print_bool("aneg-complete", val & MDIO_AN_STAT1_COMPLETE);
+	putchar(' ');
+
+	print_bool("remote-fault", val & MDIO_AN_STAT1_RFAULT);
+	fputs("\n"
+	      "                ", stdout);
+
+	print_bool("link", val & MDIO_STAT1_LSTATUS);
+	putchar('\n');
+}
+
+const struct mmd_print_device an_print_device = {
+	.print_ctrl1 = print_an_ctrl1,
+	.print_stat1 = print_an_stat1,
+};


### PR DESCRIPTION
This adds basic support for pretty-printing c45 registers. I have added support for the status registers in PMA/PMD, PCS, and AN devices. It also adds support for the c22 extended status register.