### PR TITLE
mdio: add compatibility wrapper for older kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Operations:
 Build
 -----
 
-At the moment, the kernel module (which requires at least kernel version 5.6)
+At the moment, the kernel module (which requires at least kernel version 5.2)
 has to be built separately. Set `KDIR` if building against a kernel in a
 non-standard location.
 

--- a/kernel/compat.h
+++ b/kernel/compat.h
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#ifndef _COMPAT_H_
+#define _COMPAT_H_
+
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,7,0)
+#include <linux/device.h>
+#include <linux/phy.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,4,0)
+#include <linux/string.h>
+
+static inline int _mdio_find_bus_match(struct device *dev, void *data)
+{
+	return dev->parent && sysfs_streq(dev_name(dev->parent), data);
+}
+#else
+static inline int _mdio_find_bus_match(struct device *dev, const void *data)
+{
+	return dev->parent && device_match_name(dev->parent, data);
+}
+#endif
+
+/**
+ * mdio_find_bus - Given the name of a mdiobus, find the mii_bus.
+ * @mdio_bus_np: Pointer to the mii_bus.
+ *
+ * Returns a reference to the mii_bus, or NULL if none found.  The
+ * embedded struct device will have its reference count incremented,
+ * and this must be put_deviced'ed once the bus is finished with.
+ *
+ * Abuse bus_find_device() to * reimplement the mdio_find_bus()
+ * function introduced in v5.7.
+ */
+static inline struct mii_bus *mdio_find_bus(const char *mdio_name)
+{
+	struct device *d, *p = NULL;
+
+	d = bus_find_device(&mdio_bus_type, NULL, (char *)mdio_name, _mdio_find_bus_match);
+	if (!d)
+		return NULL;
+	if (d->parent)
+		p = get_device(d->parent);
+	put_device(d);
+	return p ? to_mii_bus(p) : NULL;
+}
+#endif
+
+#endif /* _COMPAT_H_ */

--- a/kernel/mdio-netlink.c
+++ b/kernel/mdio-netlink.c
@@ -8,6 +8,7 @@
 #include <linux/phy.h>
 #include <net/genetlink.h>
 #include <net/netlink.h>
+#include "compat.h"
 
 static void c45_compat_convert(int *kdev, int *kreg, int udev, int ureg)
 {


### PR DESCRIPTION
I've found this extremely useful when trying to debug mdio on a v5.4 based vendor kernel. Hoping it is useful to others too.