### PR TITLE
mdio.h: include stdio.h

### DIFF
--- a/src/mdio/mdio.h
+++ b/src/mdio/mdio.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <linux/mdio-netlink.h>
 
 #define BIT(_n) (1 << (_n))


### PR DESCRIPTION
Otherwise `FILE` type is undefined.