### PR TITLE
mvls: Add entries for Marvvell 88E6320/88E6321

### DIFF
--- a/src/mvls/mvls.c
+++ b/src/mvls/mvls.c
@@ -201,6 +201,16 @@ const struct chip chips[] = {
 		.n_ports = 7,
 	},
 	{
+		.id = "Marvell 88E6320",
+		.family = &opal_family,
+		.n_ports = 7,
+	},
+	{
+		.id = "Marvell 88E6321",
+		.family = &opal_family,
+		.n_ports = 7,
+	},
+	{
 		.id = "Marvell 88E6190",
 		.family = &peridot_family,
 		.n_ports = 11,


### PR DESCRIPTION
Add entries for the Marvell 88E6320/88E6321 switches.

Suggested-by: Tobias Waldekranz <tobias@waldekranz.com>