### PR TITLE
Add line endings for error messages

### DIFF
--- a/src/mdio/mdio.c
+++ b/src/mdio/mdio.c
@@ -128,7 +128,7 @@ int mdio_parse_bus(const char *str, char **bus)
 	if (*bus)
 		return 0;
 
-	fprintf(stderr, "ERROR: \"%s\" does not match any known MDIO bus", str);
+	fprintf(stderr, "ERROR: \"%s\" does not match any known MDIO bus\n", str);
 	return ENODEV;
 }
 
@@ -284,7 +284,7 @@ int mdio_device_dflt_parse_val(struct mdio_device *dev,
 		goto err_invalid;
 
 	if (!mask) {
-		fprintf(stderr, "ERROR: Masking of value not allowed");
+		fprintf(stderr, "ERROR: Masking of value not allowed\n");
 		return EINVAL;
 	}
 
@@ -361,7 +361,7 @@ int mdio_common_raw_exec(struct mdio_device *dev, int argc, char **argv)
 	}
 
 	if (argv_peek(argc, argv)) {
-		fprintf(stderr, "ERROR: Unexpected argument");
+		fprintf(stderr, "ERROR: Unexpected argument\n");
 		return EINVAL;
 	}
 

--- a/src/mdio/mva.c
+++ b/src/mdio/mva.c
@@ -73,7 +73,7 @@ static int mva_parse_reg(struct mdio_device *dev, int *argcp, char ***argvp,
 	str = argv_pop(argcp, argvp);
 	tok = str ? strtok(str, ":") : NULL;
 	if (!tok) {
-		fprintf(stderr, "ERROR: PAGE:REG");
+		fprintf(stderr, "ERROR: PAGE:REG\n");
 		return EINVAL;
 	} else if (!strcmp(tok, "copper") || !strcmp(tok, "cu")) {
 		page = MVA_PAGE_COPPER;
@@ -96,7 +96,7 @@ static int mva_parse_reg(struct mdio_device *dev, int *argcp, char ***argvp,
 
 	tok = strtok(NULL, ":");
 	if (!tok) {
-		fprintf(stderr, "ERROR: Expected REG");
+		fprintf(stderr, "ERROR: Expected REG\n");
 		return EINVAL;
 	}
 

--- a/src/mdio/mvls.c
+++ b/src/mdio/mvls.c
@@ -463,7 +463,7 @@ static int mvls_parse_reg(struct mdio_device *dev, int *argcp, char ***argvp,
 	str = argv_pop(argcp, argvp);
 	tok = str ? strtok(str, ":") : NULL;
 	if (!tok) {
-		fprintf(stderr, "ERROR: Expected PORT:REG");
+		fprintf(stderr, "ERROR: Expected PORT:REG\n");
 		return EINVAL;
 	}
 
@@ -488,7 +488,7 @@ static int mvls_parse_reg(struct mdio_device *dev, int *argcp, char ***argvp,
 
 	tok = strtok(NULL, ":");
 	if (!tok) {
-		fprintf(stderr, "ERROR: Expected REG");
+		fprintf(stderr, "ERROR: Expected REG\n");
 		return EINVAL;
 	}
 


### PR DESCRIPTION
Some prints to `stderr` omitted line endings. Add line endings to these prints to make all error messages consistent.