### PR TITLE
Explicit linking behavior

### DIFF
--- a/src/mdio/Makefile.am
+++ b/src/mdio/Makefile.am
@@ -2,4 +2,5 @@ sbin_PROGRAMS = mdio
 
 mdio_SOURCES = bus.c main.c mdio.c mdio.h mva.c mvls.c phy.c print_phy.c xrs.c
 mdio_CFLAGS  = -Wall -Wextra -Werror -Wno-unused-parameter -I $(top_srcdir)/include $(mnl_CFLAGS)
+mdio_LDFLAGS = -T cmds.ld
 mdio_LDADD   = $(mnl_LIBS)

--- a/src/mdio/cmds.ld
+++ b/src/mdio/cmds.ld
@@ -1,0 +1,9 @@
+SECTIONS
+{
+    .cmds : {
+        PROVIDE(cmds_start = .);
+        *(.cmd_registry)
+        PROVIDE(cmds_end = .);
+    }
+}
+INSERT AFTER .data;

--- a/src/mdio/main.c
+++ b/src/mdio/main.c
@@ -167,7 +167,7 @@ int main(int argc, char **argv)
 	if (!arg)
 		return bus_status(bus) ? 1 : 0;
 
-	for (cmd = &__start_cmds; cmd < &__stop_cmds; cmd++) {
+	for (cmd = &cmds_start; cmd < &cmds_end; cmd++) {
 		if (!strcmp(cmd->name, arg)) {
 			argv_pop(&argc, &argv);
 			return cmd->exec(bus, argc, argv) ? 1 : 0;

--- a/src/mdio/mdio.h
+++ b/src/mdio/mdio.h
@@ -55,12 +55,13 @@ struct cmd {
 	int (*exec)(const char *bus, int argc, char **argv);
 };
 
+// Derived from https://stackoverflow.com/a/4152185
 #define DEFINE_CMD(_name, _exec) \
-  __attribute__(( section("cmds"), aligned(__alignof__(struct cmd)) )) \
+  __attribute__((externally_visible, section(".cmd_registry"), aligned(__alignof__(struct cmd)) )) \
   struct cmd _exec ## _cmd = { .name = _name, .exec = _exec }
 
-extern struct cmd __start_cmds;
-extern struct cmd __stop_cmds;
+extern struct cmd cmds_start;
+extern struct cmd cmds_end;
 
 void print_phy_bmcr   (uint16_t val);
 void print_phy_bmsr   (uint16_t val);

--- a/src/mdio/mdio.h
+++ b/src/mdio/mdio.h
@@ -57,7 +57,7 @@ struct cmd {
 
 // Derived from https://stackoverflow.com/a/4152185
 #define DEFINE_CMD(_name, _exec) \
-  __attribute__((externally_visible, section(".cmd_registry"), aligned(__alignof__(struct cmd)) )) \
+  __attribute__((used, section(".cmd_registry"), aligned(__alignof__(struct cmd)) )) \
   struct cmd _exec ## _cmd = { .name = _name, .exec = _exec }
 
 extern struct cmd cmds_start;


### PR DESCRIPTION
Previously mdio relied on GNU `ld`'s well known secret formula finding the beginning and end of sections. Compiling with LTO and optimizations seems to break that.

Now there is a linker script that explains to the linker what is happening. `used` was also added to make sure the cmd functions do not get optimized away since they are not directly referenced from `main` (might be unnecessary).

Addresses https://github.com/wkz/mdio-tools/issues/37
Testing locally seems like everything still works as expected. Let me know if it needs any changes.