### PR TITLE
build: Allow out of source builds

### DIFF
--- a/src/mdio/Makefile.am
+++ b/src/mdio/Makefile.am
@@ -2,5 +2,5 @@ sbin_PROGRAMS = mdio
 
 mdio_SOURCES = bus.c main.c mdio.c mdio.h mva.c mvls.c phy.c print_phy.c xrs.c
 mdio_CFLAGS  = -Wall -Wextra -Werror -Wno-unused-parameter -I $(top_srcdir)/include $(mnl_CFLAGS)
-mdio_LDFLAGS = -T cmds.ld
+mdio_LDFLAGS = -T $(top_srcdir)/src/mdio/cmds.ld
 mdio_LDADD   = $(mnl_LIBS)


### PR DESCRIPTION
When building out of source the file cmds.ld can't be found because it's addressed with a relative path