### PR TITLE
configure.ac: fix obsolete macro warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_CONFIG_AUX_DIR(aux)
 AM_INIT_AUTOMAKE(1.11 foreign subdir-objects)
 AM_SILENT_RULES(yes)
 
-AC_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([
 	Makefile
 	include/Makefile


### PR DESCRIPTION
Replace `AC_CONFIG_HEADER` with `AC_CONFIG_HEADERS`. Fixes the following warning:

configure.ac:8: warning: The macro `AC_CONFIG_HEADER' is obsolete.